### PR TITLE
fix(providers): correct useEffect dependency array for localStorage

### DIFF
--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -26,7 +26,7 @@ export const Providers = () => {
     const resumeData = window.localStorage.getItem("resume");
 
     if (resumeData) setResume(JSON.parse(resumeData));
-  }, [window.localStorage.getItem("resume")]);
+  }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!resume) return null;


### PR DESCRIPTION
The useEffect hook in the Providers component, responsible for loading resume data from localStorage, had a faulty dependency array `[window.localStorage.getItem("resume")]`. This caused the effect to not run as expected, leading to the `resume` data not being loaded into the store.

This change corrects the dependency array to `[]`, ensuring the effect runs once on component mount, which is the correct pattern for initializing state from localStorage. This fixes the bug where the live preview would appear blank because the resume data was not being loaded.