### PR TITLE
fix(routing): redirect logged-in users to dashboard overview

### DIFF
--- a/src/components/PublicOnly.tsx
+++ b/src/components/PublicOnly.tsx
@@ -16,7 +16,7 @@ export const PublicOnly: React.FC<Props> = ({ children }) => {
       const { data } = await supabase.auth.getUser()
       if (!mounted) return
       if (data.user) {
-        navigate(ROUTES.DASHBOARD, { replace: true })
+        navigate(`${ROUTES.DASHBOARD}/overview`, { replace: true })
       } else {
         setChecking(false)
       }
@@ -24,7 +24,7 @@ export const PublicOnly: React.FC<Props> = ({ children }) => {
     check()
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event: any, session: any) => {
-      if (session?.user) navigate(ROUTES.DASHBOARD, { replace: true })
+      if (session?.user) navigate(`${ROUTES.DASHBOARD}/overview`, { replace: true })
     })
 
     return () => {


### PR DESCRIPTION
When a logged-in user visits the landing page, they should be redirected to the dashboard. The `PublicOnly` component was redirecting to `/dashboard`, but the route was defined for `/dashboard/*`. This caused a blank page to be rendered.

This commit fixes the issue by changing the redirect in `PublicOnly` to `/dashboard/overview`, which is a valid dashboard route.