### PR TITLE
feat: Add import resume page

### DIFF
--- a/src/client/pages/dashboard/_components/sidebar.tsx
+++ b/src/client/pages/dashboard/_components/sidebar.tsx
@@ -95,6 +95,12 @@ export const Sidebar = ({ setOpen }: SidebarProps) => {
       icon: <Plus />,
     },
     {
+      path: "/dashboard/resumes/import",
+      name: t`Import Resume`,
+      shortcut: "⇧I",
+      icon: <Plus />,
+    },
+    {
       path: "/dashboard/resumes",
       name: t`Resumes`,
       shortcut: "⇧R",

--- a/src/client/pages/dashboard/resumes/import.tsx
+++ b/src/client/pages/dashboard/resumes/import.tsx
@@ -1,0 +1,19 @@
+import { t } from "@lingui/macro";
+import { Helmet } from "react-helmet-async";
+
+export const ImportResumePage = () => {
+  return (
+    <>
+      <Helmet>
+        <title>
+          {t`Import Resume`} - {t`Reactive Resume`}
+        </title>
+      </Helmet>
+
+      <div className="space-y-6">
+        <h1 className="text-3xl font-semibold tracking-tight">{t`Import Resume`}</h1>
+        <p>{t`This is the page for importing resumes.`}</p>
+      </div>
+    </>
+  );
+};

--- a/src/client/router/index.tsx
+++ b/src/client/router/index.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, createRoutesFromElements, Navigate, Route } from "
 import { BuilderLayout } from "../pages/builder/layout";
 import { builderLoader, BuilderPage } from "../pages/builder/page";
 import { DashboardLayout } from "../pages/dashboard/layout";
+import { ImportResumePage } from "../pages/dashboard/resumes/import";
 import { ResumesPage } from "../pages/dashboard/resumes/page";
 import { SettingsPage } from "../pages/dashboard/settings/page";
 import { HomeLayout } from "../pages/home/layout";
@@ -24,6 +25,7 @@ export const routes = createRoutesFromElements(
       <Route path="dashboard">
         <Route element={<DashboardLayout />}>
           <Route path="resumes" element={<ResumesPage />} />
+          <Route path="resumes/import" element={<ImportResumePage />} />
           <Route path="settings" element={<SettingsPage />} />
 
           <Route index element={<Navigate replace to="/dashboard/resumes" />} />


### PR DESCRIPTION
This commit adds a new page for importing resumes. It includes a new route, a link in the dashboard sidebar, and a placeholder page component.