### PR TITLE
Docs: Add backend environment variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,28 @@ VITE_ENABLE_NOTIFICATIONS=true
 VITE_ENABLE_REAL_TIME=true
 ```
 
+### Backend Functions Configuration
+
+In addition to the frontend application, this project includes backend services using Supabase Edge Functions (e.g., for cron jobs that fetch job listings). These functions have their own environment variables.
+
+A separate example file is provided at `supabase/functions/.env.example`. To configure the backend, you should copy this file to `.env` within the same directory (`supabase/functions/.env`) and set the variables. These variables must also be set in your Supabase project's settings under "Edge Functions".
+
+```bash
+# Navigate to the functions directory
+cd supabase/functions
+
+# Copy the environment template
+cp .env.example .env
+```
+
+The `.env` file will contain variables such as:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `FIRECRAWL_API_KEY` (optional, for enhanced job searching)
+- `JOBS_CRON_EXPR` (optional, for scheduling jobs)
+
+See the `.env.example` file for a full list and detailed comments.
+
 ### Supabase Setup
 
 1. **Create a Supabase Project**:

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------------
+# Supabase Edge Functions Environment Variables
+#
+# Copy this file to .env and fill in the values to run the functions locally.
+# These variables also need to be set in your Supabase project settings for
+# deployed functions.
+#
+# See /supabase/functions/jobs-cron/index.ts for usage.
+# ------------------------------------------------------------------------------
+
+# -- Supabase Config --
+# These are required to connect to your Supabase instance from the functions.
+# You can find these in your Supabase project's API settings.
+SUPABASE_URL="https://<your-project-ref>.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="your-supabase-service-role-key"
+
+# -- Job Cron Function (`jobs-cron`) --
+
+# (Optional) Firecrawl API Key for the "deepresearch" job source.
+# The cron job will still run without this, but the deep research feature
+# will be disabled. Get a key from https://www.firecrawl.dev/
+FIRECRAWL_API_KEY=""
+
+# (Optional) Defines the cron schedule for the job fetching function.
+# Uses standard cron syntax. If not set, the cron job will not be scheduled.
+# Example: "0 */6 * * *" runs the job every 6 hours.
+JOBS_CRON_EXPR=""
+
+# (Optional) A JSON string to configure the job sources to fetch from.
+# If not set, a default configuration will be used.
+# See /supabase/functions/_examples/job_sources.example.json for the structure.
+JOB_SOURCES=""
+
+# -- Firestore Mirroring (Optional) --
+# The `jobs-cron` function can optionally mirror the fetched jobs to a
+# Google Firestore database. This is disabled if these variables are not set.
+
+# (Optional) Your Google Cloud Project ID.
+FIREBASE_PROJECT_ID=""
+
+# (Optional) The name of the Firestore collection to store jobs in.
+FIREBASE_COLLECTION="jobs"
+
+# (Optional) A JSON string containing your Firebase service account credentials.
+# This is required for authenticating with the Firestore API.
+FIREBASE_SERVICE_ACCOUNT=""


### PR DESCRIPTION
Adds a new `.env.example` file in `supabase/functions` to document the environment variables required for the Supabase Edge Functions, including the optional `FIRECRAWL_API_KEY`.

Also updates the main `README.md` to include a section on backend configuration, pointing developers to the new example file. This clarifies the separation between frontend and backend environment variables.